### PR TITLE
Add error notification feature

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -174,6 +174,7 @@ header h1 {
 }
 .grid-item {
   display: flex;
+  position: relative;
   gap: 1rem;
   align-items: center;
   padding: 0.5rem 1rem;
@@ -197,6 +198,18 @@ header h1 {
     padding: 8px;
   }
 }
+.grid-item .item-notify {
+  display: flex;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  opacity: 0.8;
+  color: var(--error-color, #db4437);
+}
+.grid-item .item-notify.hidden {
+  display: none;
+}
+
 .grid-item .item-icon {
   display: inline-block;
   border-radius: 50% 50%;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -107,6 +107,10 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
     return this._config?.enable_map_popup || false;
   }
 
+  get _show_error_notify(): boolean {
+    return this._config?.show_error_notify || false;
+  }
+
   get _google_api_key(): string {
     return this._config?.google_api_key || '';
   }
@@ -202,7 +206,8 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
   }
 
   private _renderSwitches(): TemplateResult {
-    const switches = html` <ha-formfield .label=${`Show slides`}>
+    const switches = html`
+      <ha-formfield .label=${`Show slides`}>
         <ha-switch
           .disabled=${!this._config?.images || this._config?.images.length === 0}
           .checked=${this._show_slides !== false}
@@ -249,7 +254,15 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
           .configValue=${'enable_services_control'}
           @change=${this._valueChanged}
         ></ha-switch>
-      </ha-formfield>`;
+      </ha-formfield>
+      <ha-formfield .label=${`Show error notification`}>
+        <ha-switch
+          .checked=${this._show_error_notify !== false}
+          .configValue=${'show_error_notify'}
+          @change=${this._valueChanged}
+        ></ha-switch>
+      </ha-formfield>
+    `;
 
     return html` <div class="panel-container">
       <ha-expansion-panel

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface ShowOptions extends VehicleCardConfig {
   show_background: boolean;
   enable_map_popup: boolean;
   enable_services_control: boolean;
+  show_error_notify: boolean;
 }
 
 export interface MapPopupConfig {
@@ -94,6 +95,7 @@ export const defaultConfig: Partial<VehicleCardConfig> = {
   show_background: true,
   enable_map_popup: false,
   enable_services_control: false,
+  show_error_notify: false,
   services: {
     auxheat: false,
     charge: false,

--- a/src/vehicle-info-card.ts
+++ b/src/vehicle-info-card.ts
@@ -385,6 +385,7 @@ export class VehicleCard extends LitElement {
   }
 
   private _renderButtons(): TemplateResult {
+    const showError = this.config.show_error_notify;
     if (!this.config.show_buttons) return html``;
 
     return html`
@@ -399,6 +400,13 @@ export class VehicleCard extends LitElement {
                 <span class="primary">${cardType.name}</span>
                 <span class="secondary">${this.getSecondaryInfo(cardType.type)}</span>
               </div>
+              ${showError
+                ? html`
+                    <div class="item-notify ${this.getErrorNotify(cardType.type) ? '' : 'hidden'}">
+                      <ha-icon icon="mdi:alert-circle"></ha-icon>
+                    </div>
+                  `
+                : ''}
             </div>
           `,
         )}
@@ -1121,6 +1129,27 @@ export class VehicleCard extends LitElement {
     const formattedMinPressure = minPressure % 1 === 0 ? minPressure.toFixed(0) : minPressure.toFixed(1);
     const formattedMaxPressure = maxPressure % 1 === 0 ? maxPressure.toFixed(0) : maxPressure.toFixed(1);
     return `${formattedMinPressure} - ${formattedMaxPressure} ${tireUnit}`;
+  }
+
+  private getErrorNotify(cardType: string): boolean {
+    const { vehicleEntities } = this;
+    switch (cardType) {
+      case 'tripCards':
+        return false;
+      case 'vehicleCards':
+        const baseWarnKeys = DataKeys.vehicleWarnings.map((key) => key.key);
+        const warnKeys = [...baseWarnKeys, 'windowsClosed', 'doorStatusOverall'];
+        const hasWarning = warnKeys.some((key) => this.getBooleanState(vehicleEntities[key]?.entity_id));
+        console.log(hasWarning);
+
+        return hasWarning;
+      case 'ecoCards':
+        return false;
+      case 'tyreCards':
+        return this.getBooleanState(vehicleEntities.tirePressureWarning?.entity_id);
+      default:
+        return false;
+    }
   }
 
   /* ----------------------------- EVENTS HANDLERS ---------------------------- */


### PR DESCRIPTION
This pull request adds a new feature to display error notifications in the vehicle info card. The error notifications will be shown for specific card types based on the presence of warnings or other conditions. The feature can be enabled or disabled through the card editor.