### PR TITLE
Add selector between using the model name or a custom name for the card.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -71,9 +71,10 @@ export interface VehicleCardConfig extends LovelaceCardConfig {
   name?: string;
   device_tracker?: string;
   google_api_key?: string;
+  selected_language?: string | null;
+  model_name?: string;
   map_popup_config: MapPopupConfig;
   selected_theme: ThemesConfig;
-  selected_language?: string | null;
   services: Services;
   vehicle_card?: LovelaceCardConfig[];
   trip_card?: LovelaceCardConfig[];
@@ -135,7 +136,7 @@ export interface CardTypeConfig {
 // Default configuration for the Vehicle Card.
 export const defaultConfig: Partial<VehicleCardConfig> = {
   type: 'custom:vehicle-info-card',
-  name: 'Mercedes Benz',
+  name: 'Mercedes Vehicle Card',
   entity: '',
   show_slides: false,
   show_map: false,

--- a/src/utils/get-device-entities.ts
+++ b/src/utils/get-device-entities.ts
@@ -9,6 +9,9 @@ import { combinedFilters } from '../const/const';
  */
 
 export async function getVehicleEntities(hass: HomeAssistant, config: { entity?: string }): Promise<VehicleEntities> {
+  if (!config.entity) {
+    return {};
+  }
   const allEntities = await hass.callWS<Required<VehicleEntity>[]>({
     type: 'config/entity_registry/list',
   });


### PR DESCRIPTION
This pull request refactors`VehicleCardEditor` class now includes a `model_name` property that can be selected or entered manually using a combo-box. This allows users to choose between using the model name or a custom name for the card.