### PR TITLE
Split English into UK and US variants

### DIFF
--- a/src/languages/en_uk.json
+++ b/src/languages/en_uk.json
@@ -1,6 +1,5 @@
 {
     "name": "English",
-    "nativeName": "English",
     "card": {
         "common": {
             "lastUpdate": "Last update",
@@ -29,16 +28,16 @@
         "chargingOverview": {
             "chargingPower": "Power",
             "maxSoc": "Maximum",
-            "selectedProgram": "Program",
+            "selectedProgram": "Programme",
             "soc": "Current state"
         },
         "doorAttributes": {
-            "decklidstatus": "Luggage compartment",
+            "decklidstatus": "Load compartment",
             "doorstatusfrontleft": "Door front left",
             "doorstatusfrontright": "Door front right",
             "doorstatusrearleft": "Door rear left",
             "doorstatusrearright": "Door rear right",
-            "enginehoodstatus": "Engine hood",
+            "enginehoodstatus": "Bonnet",
             "sunroofstatus": "Sunroof"
         },
         "ecoCard": {
@@ -52,12 +51,12 @@
         "lockAttributes": {
             "doorlockstatusfrontleft": "Door lock front left",
             "doorlockstatusfrontright": "Door lock front right",
-            "doorlockstatusgas": "Fuel filler flap lock",
+            "doorlockstatusgas": "Fuel flap lock",
             "doorlockstatusrearleft": "Door lock rear left",
             "doorlockstatusrearright": "Door lock rear right"
         },
         "serviceData": {
-            "labelChargeProgram": "Charge program",
+            "labelChargeProgram": "Charge programme",
             "labelCity": "City",
             "labelClose": "Close",
             "labelDepartureTime": "Departure time",
@@ -129,8 +128,8 @@
             "adBlueLevel": "AdBlue level",
             "averageSpeedReset": "Average speed",
             "averageSpeedStart": "Average speed",
-            "distanceReset": "Distance traveled",
-            "distanceStart": "Distance traveled",
+            "distanceReset": "Distance travelled",
+            "distanceStart": "Distance travelled",
             "drivenTimeReset": "Driving time",
             "drivenTimeStart": "Driving time",
             "electricConsumptionReset": "Average consumption",
@@ -165,8 +164,8 @@
             "lowCoolantLevel": "Coolant",
             "lowWashWater": "Washer fluid",
             "parkBrake": "Parking brake",
-            "starterBatteryState": "Starter battery",
-            "tirePressureWarning": "Tire pressure",
+            "starterBatteryState": "12v battery",
+            "tirePressureWarning": "Tyre pressure",
             "vehicleStatus": "Vehicle status",
             "vehicleWarnings": "Warnings",
             "windowsClosed": "Windows"

--- a/src/languages/en_uk.json
+++ b/src/languages/en_uk.json
@@ -1,5 +1,5 @@
 {
-    "name": "English",
+    "name": "English(UK)",
     "card": {
         "common": {
             "lastUpdate": "Last update",

--- a/src/languages/en_us.json
+++ b/src/languages/en_us.json
@@ -1,5 +1,5 @@
 {
-    "name": "English",
+    "name": "English(US)",
     "card": {
         "common": {
             "lastUpdate": "Last update",

--- a/src/languages/en_us.json
+++ b/src/languages/en_us.json
@@ -1,0 +1,227 @@
+{
+    "name": "English",
+    "card": {
+        "common": {
+            "lastUpdate": "Last update",
+            "stateCharging": "Charging",
+            "stateClosed": "Closed",
+            "stateLocked": "Locked",
+            "stateLockedInt": "Locked int",
+            "stateNotExisting": "Not existing",
+            "stateOpen": "Open",
+            "stateParkBrakeOff": "Released",
+            "stateParkBrakeOn": "Engaged",
+            "statePartlyUnlocked": "Partly unlocked",
+            "stateUnknown": "Unknown",
+            "stateUnlocked": "Unlocked",
+            "titleRemoteControl": "Remote control",
+            "titleServices": "Services",
+            "toastCommandSent": "Command sent sucess!",
+            "toastImageError": "Error uploading image. Only PNG and JPEG files are allowed."
+        },
+        "cardType": {
+            "ecoCards": "Eco display",
+            "tripCards": "Trip data",
+            "tyreCards": "Tire pressure",
+            "vehicleCards": "Vehicle status"
+        },
+        "chargingOverview": {
+            "chargingPower": "Power",
+            "maxSoc": "Maximum",
+            "selectedProgram": "Program",
+            "soc": "Current state"
+        },
+        "doorAttributes": {
+            "decklidstatus": "Deck lid",
+            "doorstatusfrontleft": "Door front left",
+            "doorstatusfrontright": "Door front right",
+            "doorstatusrearleft": "Door rear left",
+            "doorstatusrearright": "Door rear right",
+            "enginehoodstatus": "Engine hood",
+            "sunroofstatus": "Sunroof"
+        },
+        "ecoCard": {
+            "ecoDisplay": "Eco display",
+            "ecoScore": "Scores",
+            "ecoScoreAcceleraion": "Acceleraion",
+            "ecoScoreBonusRange": "Bonus range",
+            "ecoScoreConstant": "Constant",
+            "ecoScoreFreeWheel": "Free wheel"
+        },
+        "lockAttributes": {
+            "doorlockstatusfrontleft": "Door lock front left",
+            "doorlockstatusfrontright": "Door lock front right",
+            "doorlockstatusgas": "Gas lock",
+            "doorlockstatusrearleft": "Door lock rear left",
+            "doorlockstatusrearright": "Door lock rear right"
+        },
+        "serviceData": {
+            "labelChargeProgram": "Charge program",
+            "labelCity": "City",
+            "labelClose": "Close",
+            "labelDepartureTime": "Departure time",
+            "labelDurationTime": "Duration time",
+            "labelLatitude": "Latitude",
+            "labelLockCar": "Lock car",
+            "labelLongitude": "Longitude",
+            "labelMaxStateOfCharge": "Max state of charge",
+            "labelMoreInfo": "More info",
+            "labelMove": "Move",
+            "labelNoSelection": "No selection",
+            "labelOpen": "Open",
+            "labelPostCode": "Zip code",
+            "labelSave": "Save",
+            "labelSend": "Send",
+            "labelSetMaxSoc": "Set maximum",
+            "labelSetProgram": "Set program",
+            "labelStart": "Start",
+            "labelStartTime": "Start time",
+            "labelStop": "Stop",
+            "labelStopTime": "Stop time",
+            "labelStreet": "Street",
+            "labelTilt": "Tilt",
+            "labelTime1": "Time 1",
+            "labelTime2": "Time 2",
+            "labelTime3": "Time 3",
+            "labelTimeSelection": "Time selection",
+            "labelTitle": "Title",
+            "labelUnlockCar": "Unlock car",
+            "labelWindowFrontLeft": "Front left",
+            "labelWindowFrontRight": "Front right",
+            "labelWindowRearLeft": "Rear left",
+            "labelWindowRearRight": "Rear right"
+        },
+        "servicesCtrl": {
+            "auxheat": "Auxiliary heating",
+            "charge": "Charge",
+            "doorsLock": "Security",
+            "engine": "Engine control",
+            "preheat": "Pre-conditioning",
+            "sendRoute": "Send route",
+            "sigPos": "Signal position",
+            "sunroof": "Sunroof",
+            "windows": "Windows"
+        },
+        "starterBattery": {
+            "notAvailable": "Not available",
+            "partlyCharged": "Partly charged",
+            "remoteServiceDisabled": "Remote service disabled",
+            "stateOk": "Ok",
+            "vehicleNoLongerAvailable": "Vehicle no longer available"
+        },
+        "sunroofState": {
+            "antiBoomingLifting": "Anti-booming lifting",
+            "antiBoomingPosition": "Anti-booming position",
+            "closing": "Closing",
+            "closingLifting": "Closing lifting",
+            "intermediatePosition": "Intermediate position",
+            "liftingIntermediate": "Lifting intermediate",
+            "liftingOpen": "Lifting open",
+            "opening": "Opening",
+            "openingLifting": "Opening lifting",
+            "running": "Running",
+            "slidingIntermediate": "Sliding intermediate",
+            "stateClosed": "Closed",
+            "stateOpen": "Open"
+        },
+        "tripCard": {
+            "adBlueLevel": "AdBlue level",
+            "averageSpeedReset": "Average speed",
+            "averageSpeedStart": "Average speed",
+            "distanceReset": "Distance traveled",
+            "distanceStart": "Distance traveled",
+            "drivenTimeReset": "Driving time",
+            "drivenTimeStart": "Driving time",
+            "electricConsumptionReset": "Average consumption",
+            "electricConsumptionStart": "Average consumption",
+            "fromReset": "From reset",
+            "fromStart": "From start",
+            "fuelLevel": "Fuel level",
+            "liquidConsumptionReset": "Average consumption",
+            "liquidConsumptionStart": "Average consumption",
+            "maxSoc": "Max state of charge",
+            "odometer": "Odometer",
+            "overview": "Overview",
+            "rangeElectric": "Range",
+            "rangeLiquid": "Range",
+            "soc": "State of charge"
+        },
+        "TireCard": {
+            "tirePressureFrontLeft": "Front left",
+            "tirePressureFrontRight": "Front right",
+            "tirePressureRearLeft": "Rear left",
+            "tirePressureRearRight": "Rear right",
+            "tireWarningOk": "No pressure loss detected",
+            "tireWarningProblem": "Pressure loss detected. Check tires.",
+            "tyrePressure": "Tire pressures"
+        },
+        "vehicleCard": {
+            "doorStatusOverall": "Doors",
+            "engineLight": "Engine light",
+            "ignitionState": "Ignition state",
+            "lockSensor": "Lock status",
+            "lowBrakeFluid": "Brake fluid",
+            "lowCoolantLevel": "Coolant",
+            "lowWashWater": "Washer fluid",
+            "parkBrake": "Parking brake",
+            "starterBatteryState": "Starter battery",
+            "tirePressureWarning": "Tire pressure",
+            "vehicleStatus": "Vehicle status",
+            "vehicleWarnings": "Warnings",
+            "windowsClosed": "Windows"
+        },
+        "windowAttributes": {
+            "windowstatusfrontleft": "Window front left",
+            "windowstatusfrontleftblind": "Window front left blind",
+            "windowstatusfrontright": "Window front right",
+            "windowstatusfrontrightblind": "Window front right blind",
+            "windowstatusrearleft": "Window rear left",
+            "windowstatusrearleftblind": "Window rear left blind",
+            "windowstatusrearright": "Window rear right",
+            "windowstatusrearrightblind": "Window rear right blind"
+        }
+    },
+    "editor": {
+        "buttonConfig": {
+            "desc": "Configure the subcards for individual buttons.",
+            "title": "Buttons configuration"
+        },
+        "common": {
+            "checkAll": "Check all",
+            "infoButton": "Select the card you want to configure.",
+            "infoImages": "There is no need to add a '-' for each line. Each line will be treated as a separate URL automatically.",
+            "infoMap": "This is configuration for map popup.",
+            "infoServices": "Choose which services you want to enable. If a service is disabled, it will not be shown in the card.",
+            "uncheckAll": "Uncheck all"
+        },
+        "imagesConfig": {
+            "desc": "Add the URLs of the images.",
+            "title": "Image configuration"
+        },
+        "mapConfig": {
+            "desc": "Choose the configuration for the map",
+            "title": "Map configuration"
+        },
+        "servicesConfig": {
+            "desc": "Choose the services you want to enable.",
+            "title": "Services configuration"
+        },
+        "showConfig": {
+            "desc": "Choose the items you want to display.",
+            "title": "Show configuration"
+        },
+        "showOpts": {
+            "enable_map_popup": "Enable map popup",
+            "enable_services_control": "Enable services control",
+            "show_background": "Show background",
+            "show_buttons": "Show buttons",
+            "show_error_notify": "Show error notification",
+            "show_map": "Show map",
+            "show_slides": "Show slides"
+        },
+        "themeLangConfig": {
+            "desc": "Choose the theme and language.",
+            "title": "Themes & Language"
+        }
+    }
+}

--- a/src/localize/languageList.json
+++ b/src/localize/languageList.json
@@ -1,7 +1,8 @@
 [
   "cs.json",
   "de.json",
-  "en.json",
+  "en_uk.json",
+  "en_us.json",
   "fr.json",
   "lt.json",
   "pl.json",

--- a/src/localize/string.json
+++ b/src/localize/string.json
@@ -1,6 +1,5 @@
 {
-    "name": "English",
-    "nativeName": "English",
+    "name": "English(UK)",
     "card": {
         "common": {
             "lastUpdate": "Last update",
@@ -29,16 +28,16 @@
         "chargingOverview": {
             "chargingPower": "Power",
             "maxSoc": "Maximum",
-            "selectedProgram": "Program",
+            "selectedProgram": "Programme",
             "soc": "Current state"
         },
         "doorAttributes": {
-            "decklidstatus": "Luggage compartment",
+            "decklidstatus": "Load compartment",
             "doorstatusfrontleft": "Door front left",
             "doorstatusfrontright": "Door front right",
             "doorstatusrearleft": "Door rear left",
             "doorstatusrearright": "Door rear right",
-            "enginehoodstatus": "Engine hood",
+            "enginehoodstatus": "Bonnet",
             "sunroofstatus": "Sunroof"
         },
         "ecoCard": {
@@ -52,12 +51,12 @@
         "lockAttributes": {
             "doorlockstatusfrontleft": "Door lock front left",
             "doorlockstatusfrontright": "Door lock front right",
-            "doorlockstatusgas": "Fuel filler flap lock",
+            "doorlockstatusgas": "Fuel flap lock",
             "doorlockstatusrearleft": "Door lock rear left",
             "doorlockstatusrearright": "Door lock rear right"
         },
         "serviceData": {
-            "labelChargeProgram": "Charge program",
+            "labelChargeProgram": "Charge programme",
             "labelCity": "City",
             "labelClose": "Close",
             "labelDepartureTime": "Departure time",
@@ -129,8 +128,8 @@
             "adBlueLevel": "AdBlue level",
             "averageSpeedReset": "Average speed",
             "averageSpeedStart": "Average speed",
-            "distanceReset": "Distance traveled",
-            "distanceStart": "Distance traveled",
+            "distanceReset": "Distance travelled",
+            "distanceStart": "Distance travelled",
             "drivenTimeReset": "Driving time",
             "drivenTimeStart": "Driving time",
             "electricConsumptionReset": "Average consumption",
@@ -165,8 +164,8 @@
             "lowCoolantLevel": "Coolant",
             "lowWashWater": "Washer fluid",
             "parkBrake": "Parking brake",
-            "starterBatteryState": "Starter battery",
-            "tirePressureWarning": "Tire pressure",
+            "starterBatteryState": "12v battery",
+            "tirePressureWarning": "Tyre pressure",
             "vehicleStatus": "Vehicle status",
             "vehicleWarnings": "Warnings",
             "windowsClosed": "Windows"


### PR DESCRIPTION
The "English" text has a mix of American and British terminology and spellings
Tire/Tyre
Program/Programme
Deck lid/Load compartment
Hood/Bonnet
Gas lock/Fuel flap lock
Distance traveled/Distance travelled

I have replace the en.json file with two variants en_uk.json and en_us.json