### PR TITLE
Update range info bar styling and add hybrid car option

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -77,6 +77,14 @@ header h1 {
   transition: all 0.5s ease;
   margin-bottom: var(--vic-gutter-gap);
 }
+.combined-info-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: fit-content;
+}
 
 .info-box {
   --mdc-icon-size: 17px;
@@ -88,8 +96,17 @@ header h1 {
   height: fit-content;
   gap: var(--vic-gutter-gap);
   flex-wrap: wrap;
-  /* opacity: 0.8; */
-  /* text-transform: capitalize; */
+}
+
+.info-box.range {
+  flex-wrap: nowrap !important;
+  justify-content: center;
+  text-wrap: nowrap;
+  .item {
+    display: flex;
+    align-items: center;
+    gap: 4px !important;
+  }
 }
 
 .info-box .item {
@@ -153,15 +170,18 @@ header h1 {
   background-color: #909090;
   border-radius: 5px;
   position: relative;
-  .fuel-level-bar {
-    position: absolute;
-    background-color: #4caf50;
-    border-radius: 5px;
-    transition: width 0.5s ease;
-    height: 5px;
-  }
+}
+.fuel-level-bar {
+  position: absolute;
+  background-color: #4caf50;
+  border-radius: 5px;
+  transition: width 0.5s ease;
+  height: 5px;
 }
 
+.fuel-level-bar.electric {
+  background-color: #2196f3 !important;
+}
 .grid-container {
   display: grid;
   grid-template-columns: repeat(2, minmax(140px, 1fr));

--- a/src/vehicle-info-card.ts
+++ b/src/vehicle-info-card.ts
@@ -44,6 +44,7 @@ import './components/remote-control';
 import { localize } from './localize/localize';
 import { formatTimestamp, convertMinutes } from './utils/helpers';
 import { setupCardListeners } from './utils/ha-helpers';
+// import { getVehicleEntities } from './test/get-device-entities_test';
 import { getVehicleEntities } from './utils/ha-helpers';
 
 const HELPERS = (window as any).loadCardHelpers ? (window as any).loadCardHelpers() : undefined;
@@ -397,14 +398,14 @@ export class VehicleCard extends LitElement implements LovelaceCard {
       getEntityInfo(this.vehicleEntities[entity]?.entity_id),
     );
 
-    const renderInfoBox = (icon: string, state: number, fuelInfo: string, rangeInfo: string) => html`
-      <div class="info-box">
+    const renderInfoBox = (icon: string, state: number, fuelInfo: string, rangeInfo: string, eletric: boolean) => html`
+      <div class="info-box range">
         <div class="item">
           <ha-icon icon="${icon}"></ha-icon>
           <div><span>${fuelInfo}</span></div>
         </div>
         <div class="fuel-wrapper">
-          <div class="fuel-level-bar" style="width: ${state}%;"></div>
+          <div class="fuel-level-bar ${eletric ? 'electric' : ''}" style="width: ${state}%;"></div>
         </div>
         <div class="item">
           <span>${rangeInfo}</span>
@@ -412,11 +413,49 @@ export class VehicleCard extends LitElement implements LovelaceCard {
       </div>
     `;
 
-    return fuelInfo?.state && rangeLiquidInfo?.state
-      ? renderInfoBox('mdi:gas-station', fuelInfo.state, fuelInfo.stateDisplay, rangeLiquidInfo.stateDisplay)
-      : rangeElectricInfo?.state && socInfo?.state
-        ? renderInfoBox('mdi:ev-station', socInfo.state, socInfo.stateDisplay, rangeElectricInfo.stateDisplay)
-        : undefined;
+    const renderBothInfoBoxes = () =>
+      html` <div class="combined-info-box">
+        ${fuelInfo && rangeLiquidInfo
+          ? renderInfoBox(
+              'mdi:gas-station',
+              fuelInfo.state!,
+              fuelInfo.stateDisplay!,
+              rangeLiquidInfo.stateDisplay!,
+              false,
+            )
+          : ''}
+        ${socInfo && rangeElectricInfo
+          ? renderInfoBox(
+              'mdi:ev-station',
+              socInfo.state!,
+              socInfo.stateDisplay!,
+              rangeElectricInfo.stateDisplay!,
+              true,
+            )
+          : ''}
+      </div>`;
+
+    if (rangeLiquidInfo && fuelInfo && rangeElectricInfo && socInfo) {
+      return renderBothInfoBoxes();
+    } else if (rangeLiquidInfo && fuelInfo) {
+      return renderInfoBox(
+        'mdi:gas-station',
+        fuelInfo.state!,
+        fuelInfo.stateDisplay!,
+        rangeLiquidInfo.stateDisplay!,
+        false,
+      );
+    } else if (rangeElectricInfo && socInfo) {
+      return renderInfoBox(
+        'mdi:ev-station',
+        socInfo.state!,
+        socInfo.stateDisplay!,
+        rangeElectricInfo.stateDisplay!,
+        true,
+      );
+    } else {
+      return undefined;
+    }
   }
 
   private _renderHeaderSlides(): TemplateResult {


### PR DESCRIPTION
This pull request updates the styling of the range info bar and adds an option for hybrid cars. The range info bar now displays the fuel level and range information in a more visually appealing way. Additionally, the option to display the range for electric cars has been added.