### PR TITLE
Add charge flap DC status to door attributes

### DIFF
--- a/src/const/const.ts
+++ b/src/const/const.ts
@@ -58,6 +58,7 @@ const sensorDeviceFilters: {
   soc: { prefix: 'sensor.', suffix: 'soc' },
   chargingPower: { suffix: '_chargingpowerkw' },
   iginitionState: { suffix: '_ignitionstate' },
+  chargeFlapDCStatus: { suffix: '_chargeflapdcstatus' },
 };
 
 export const combinedFilters = { ...binarySensorsFilters, ...sensorDeviceFilters };

--- a/src/const/state-mapping.ts
+++ b/src/const/state-mapping.ts
@@ -26,6 +26,7 @@ const createDoorStatus = (lang: string) => ({
   '2': localize('card.common.stateNotExisting', lang),
   '3': localize('card.common.stateUnknown', lang),
 });
+
 export const doorStatus = createDoorStatus;
 
 const createLockStates = (lang: string) => ({
@@ -137,6 +138,16 @@ export const doorAttributes = (lang: string) => ({
       '10': 'card.sunroofState.intermediatePosition',
       '11': 'card.sunroofState.openingLifting',
       '12': 'card.sunroofState.closingLifting',
+    },
+    lang,
+  ),
+  chargeflapdcstatus: createNameStateWithMap(
+    'card.doorAttributes.chargeflapdcstatus',
+    {
+      '0': 'card.common.stateOpen',
+      '1': 'card.common.stateClosed',
+      '2': 'card.common.statePressed',
+      '3': 'card.common.stateUnknown',
     },
     lang,
   ),

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -177,9 +177,10 @@ ha-alert>.alert-icon {
 }
 
 .sub-card-title {
-  display: flex;
+  display: inline-flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
   gap: 8px;
   color: var(--secondary-text-color);
+  text-transform: uppercase;
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5,6 +5,7 @@
   --vic-icon-border-radius: 50%;
   --vic-icon-shape-color: rgba(var(--rgb-primary-text-color), 0.05);
 }
+
 *:focus {
   outline: none;
 }
@@ -77,6 +78,7 @@ header h1 {
   transition: all 0.5s ease;
   margin-bottom: var(--vic-gutter-gap);
 }
+
 .combined-info-box {
   display: flex;
   justify-content: center;
@@ -102,6 +104,7 @@ header h1 {
   flex-wrap: nowrap !important;
   justify-content: center;
   text-wrap: nowrap;
+
   .item {
     display: flex;
     align-items: center;
@@ -123,6 +126,7 @@ header h1 {
   ha-card {
     padding: 0.5rem;
   }
+
   .info-box .item .base-menu {
     font-size: 0.8rem;
   }
@@ -145,7 +149,8 @@ header h1 {
 }
 
 .info-box.charge.active {
-  max-height: 100px; /* Adjust this to be more than the expected height of the content */
+  max-height: 100px;
+  /* Adjust this to be more than the expected height of the content */
   opacity: 1;
   padding-block: 0.5rem;
 }
@@ -171,6 +176,7 @@ header h1 {
   border-radius: 5px;
   position: relative;
 }
+
 .fuel-level-bar {
   position: absolute;
   background-color: #4caf50;
@@ -182,6 +188,7 @@ header h1 {
 .fuel-level-bar.electric {
   background-color: #2196f3 !important;
 }
+
 .grid-container {
   display: grid;
   grid-template-columns: repeat(2, minmax(140px, 1fr));
@@ -208,10 +215,12 @@ header h1 {
   transition: all 0.3s ease-out;
   opacity: 1;
   cursor: pointer;
+
   &:hover {
     box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.3);
   }
 }
+
 /* @media screen and (max-width: 768px) {
   .grid-item {
     padding: 8px;
@@ -228,6 +237,7 @@ header h1 {
   color: var(--error-color, #db4437);
   --mdc-icon-size: 1.4rem;
 }
+
 .grid-item .item-notify.hidden {
   display: none;
 }
@@ -259,11 +269,13 @@ header h1 {
   transition-duration: 280ms;
   transition-timing-function: ease-out;
 }
+
 .grid-item .item-content {
   display: flex;
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
+
   .primary {
     font-weight: 500;
     font-size: 1rem;
@@ -272,6 +284,7 @@ header h1 {
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
   .secondary {
     color: var(--secondary-text-color);
     /* text-transform: capitalize; */
@@ -297,11 +310,9 @@ header h1 {
   left: -15px;
   width: 40%;
   height: 100%;
-  background-image: linear-gradient(
-    to left,
-    transparent 0,
-    var(--secondary-background-color, var(--card-background-color, #fff)) 100%
-  );
+  background-image: linear-gradient(to left,
+      transparent 0,
+      var(--secondary-background-color, var(--card-background-color, #fff)) 100%);
 }
 
 .marquee {
@@ -316,9 +327,11 @@ header h1 {
   0% {
     transform: translateX(0%);
   }
+
   50% {
     transform: translateX(-50%);
   }
+
   100% {
     transform: translateX(0%);
   }
@@ -330,11 +343,13 @@ header h1 {
   align-items: center;
   margin-bottom: 1rem;
 }
+
 .added-card-header .headder-btn {
   cursor: pointer;
   color: var(--secondary-text-color);
   opacity: 0.5;
   transition: opacity 0.3s;
+
   &:hover {
     opacity: 1;
   }
@@ -367,10 +382,12 @@ header h1 {
   opacity: 0.5;
   font-size: 0.8rem;
 }
+
 #cards-wrapper {
   animation: fadeIn 0.5s ease-in-out;
   position: relative;
 }
+
 #main-wrapper {
   animation: fadeIn 0.3s ease;
   position: relative;
@@ -420,10 +437,12 @@ header h1 {
 .slide-right-exit-active {
   transform: translateX(100%);
 }
+
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -452,6 +471,7 @@ header h1 {
   0% {
     transform: translateY(-100%);
   }
+
   100% {
     transform: translateY(0);
   }
@@ -492,33 +512,40 @@ header h1 {
   background: none !important;
   padding: 0px;
 }
+
 .data-row {
   display: flex;
   justify-content: space-between;
   padding: var(--vic-gutter-gap);
   border-bottom: 1px solid #444;
+  overflow: hidden;
 }
 
 .data-row .data-value-unit {
   cursor: pointer;
+  text-align: end;
+  text-wrap: nowrap;
 }
 
-.data-row > div > span {
-  height: 100%;
-  display: flex;
+.data-row .data-label {
+  height: auto;
+  display: inline-block;
   align-items: flex-end;
   margin-inline-start: 8px;
+  text-transform: none;
 }
 
 .data-row:last-child {
   border-bottom: none;
   padding-bottom: 0;
 }
+
 .data-row div {
   display: flex;
   align-items: center;
   gap: var(--vic-gutter-gap);
 }
+
 .data-icon {
   color: var(--secondary-text-color);
 }
@@ -579,6 +606,7 @@ dialog::backdrop {
   0% {
     transform: translateY(-100%);
   }
+
   100% {
     transform: translateY(0);
   }
@@ -588,6 +616,7 @@ dialog::backdrop {
   0% {
     transform: translateX(-50%);
   }
+
   100% {
     transform: translateX(100%);
   }
@@ -618,6 +647,7 @@ dialog::backdrop {
   opacity: 0.5;
   cursor: pointer;
   transition: opacity 0.3s;
+
   &:hover {
     opacity: 1;
   }
@@ -666,6 +696,7 @@ dialog::backdrop {
   text-align: center;
   margin: 0;
 }
+
 .tyre-name {
   color: var(--secondary-text-color);
   text-align: left;
@@ -674,6 +705,7 @@ dialog::backdrop {
   letter-spacing: 1.5px;
   text-wrap: nowrap;
 }
+
 .tyre-info {
   display: flex;
   justify-content: center;
@@ -715,8 +747,10 @@ dialog::backdrop {
 }
 
 .loading-image img {
-  width: 100px; /* Adjust size as needed */
-  height: 100px; /* Adjust size as needed */
+  width: 100px;
+  /* Adjust size as needed */
+  height: 100px;
+  /* Adjust size as needed */
   object-fit: cover;
   animation: zoomRotate 2s linear infinite;
 }
@@ -726,10 +760,12 @@ dialog::backdrop {
     transform: scale(0) rotate(0deg);
     opacity: 0;
   }
+
   50% {
     transform: scale(1) rotate(180deg);
     opacity: 0.7;
   }
+
   100% {
     transform: scale(0) rotate(360deg);
     opacity: 0;

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -293,7 +293,7 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
     if (!this.hass) return html``;
     const sysLang = this._system_language;
     const langOpts = [
-      { key: sysLang, name: 'System', nativeName: 'System' },
+      { key: 'system', name: 'System', nativeName: 'System' },
       ...languageOptions.sort((a, b) => a.name.localeCompare(b.name)),
     ];
     const themesConfig = html`
@@ -792,6 +792,12 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
           [configValue]: newValue,
         },
       };
+    } else if (configValue === 'selected_language') {
+      newValue = target.value === 'system' ? this.hass.language : target.value;
+      this._config = {
+        ...this._config,
+        [configValue]: newValue,
+      };
     } else if (['theme', 'mode'].includes(configValue)) {
       newValue = target.value;
       this._config = {
@@ -829,6 +835,7 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
     this.dispatchEvent(ev);
     console.log('Test event dispatched:', detail);
   }
+
   static get styles(): CSSResultGroup {
     return editorcss;
   }

--- a/src/languages/cs.json
+++ b/src/languages/cs.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Částečně odemčeno",
             "stateUnknown": "Neznámý",
             "stateUnlocked": "Odemknuté",
+            "statePressed": "Stisknuto",
             "titleRemoteControl": "Vzdálené ovládání",
             "titleServices": "Služby",
             "toastCommandSent": "Příkaz odeslán úspěšně!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Zadní levé dveře",
             "doorstatusrearright": "Zadní pravé dveře",
             "enginehoodstatus": "Kapota",
-            "sunroofstatus": "Střešní okno"
+            "sunroofstatus": "Střešní okno",
+            "chargeflapdcstatus": "Krytka nabíjecího zásuvu"
         },
         "ecoCard": {
             "ecoDisplay": "Ukazatel ECO",

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Teilweise entriegelt",
             "stateUnknown": "Unbekannt",
             "stateUnlocked": "Entriegelt",
+            "statePressed": "Gedrückt",
             "titleRemoteControl": "Fernbedienung",
             "titleServices": "Dienste",
             "toastCommandSent": "Befehl gesendet!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Tür hinten links",
             "doorstatusrearright": "Tür hinten rechts",
             "enginehoodstatus": "Motorhaube",
-            "sunroofstatus": "Schiebedach"
+            "sunroofstatus": "Schiebedach",
+            "chargeflapdcstatus": "Ladeklappenstatus"
         },
         "ecoCard": {
             "ecoDisplay": "Ökoanzeige",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Partly unlocked",
             "stateUnknown": "Unknown",
             "stateUnlocked": "Unlocked",
+            "statePressed": "Pressed",
             "titleRemoteControl": "Remote control",
             "titleServices": "Services",
             "toastCommandSent": "Command sent sucess!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Door rear left",
             "doorstatusrearright": "Door rear right",
             "enginehoodstatus": "Engine hood",
-            "sunroofstatus": "Sunroof"
+            "sunroofstatus": "Sunroof",
+            "chargeflapdcstatus": "Charging socket flap"
         },
         "ecoCard": {
             "ecoDisplay": "Eco display",

--- a/src/languages/en_GB.json
+++ b/src/languages/en_GB.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Partly unlocked",
             "stateUnknown": "Unknown",
             "stateUnlocked": "Unlocked",
+            "statePressed": "Pressed",
             "titleRemoteControl": "Remote control",
             "titleServices": "Services",
             "toastCommandSent": "Command sent sucess!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Door rear left",
             "doorstatusrearright": "Door rear right",
             "enginehoodstatus": "Bonnet",
-            "sunroofstatus": "Sunroof"
+            "sunroofstatus": "Sunroof",
+            "chargeflapdcstatus": "Charging socket flap"
         },
         "ecoCard": {
             "ecoDisplay": "Eco display",

--- a/src/languages/fr.json
+++ b/src/languages/fr.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Partiellement déverrouillé",
             "stateUnknown": "Inconnu",
             "stateUnlocked": "Déverrouillé",
+            "statePressed": "Appuyé",
             "titleRemoteControl": "Télécommande",
             "titleServices": "Services",
             "toastCommandSent": "Commande envoyée avec succès !",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Porte arrière gauche",
             "doorstatusrearright": "Porte arrière droite",
             "enginehoodstatus": "Capot moteur",
-            "sunroofstatus": "Toit ouvrant"
+            "sunroofstatus": "Toit ouvrant",
+            "chargeflapdcstatus": "Trappe de charge"
         },
         "ecoCard": {
             "ecoDisplay": "Affichage éco",

--- a/src/languages/lt.json
+++ b/src/languages/lt.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Iš dalies atrakinta",
             "stateUnknown": "Nežinomas",
             "stateUnlocked": "Atrakinta",
+            "statePressed": "Paspausta",
             "titleRemoteControl": "Nuotolinis valdymas",
             "titleServices": "Paslaugos",
             "toastCommandSent": "Komanda išsiųsta sėkmingai!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Galinės kairės pusės durys",
             "doorstatusrearright": "Galinės dešinės pusės durys",
             "enginehoodstatus": "Variklio gaubtas",
-            "sunroofstatus": "Stoglangis"
+            "sunroofstatus": "Stoglangis",
+            "chargeflapdcstatus": "Įkrovos lizdas"
         },
         "ecoCard": {
             "ecoDisplay": "Eco ekranas",

--- a/src/languages/pl.json
+++ b/src/languages/pl.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Częściowo odblokowane",
             "stateUnknown": "Nieznany",
             "stateUnlocked": "Odblokowane",
+            "statePressed": "Naciśnięte",
             "titleRemoteControl": "Zdalne sterowanie",
             "titleServices": "Usługi",
             "toastCommandSent": "Polecenie wysłane pomyślnie!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Tylne lewe drzwi",
             "doorstatusrearright": "Tylne prawe drzwi",
             "enginehoodstatus": "Maska silnika",
-            "sunroofstatus": "Szyberdach"
+            "sunroofstatus": "Szyberdach",
+            "chargeflapdcstatus": "Klapa gniazda ładowania"
         },
         "ecoCard": {
             "ecoDisplay": "Status ECO",

--- a/src/languages/sk.json
+++ b/src/languages/sk.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Čiastočne odomknuté",
             "stateUnknown": "Neznáme",
             "stateUnlocked": "Odomknuté",
+            "statePressed": "Stlačené",
             "titleRemoteControl": "Vzdialené ovládanie",
             "titleServices": "Služby",
             "toastCommandSent": "Príkaz úspešne odoslaný!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Zadné ľavé dvere",
             "doorstatusrearright": "Zadné pravé dvere",
             "enginehoodstatus": "Kapota motora",
-            "sunroofstatus": "Strešné okno"
+            "sunroofstatus": "Strešné okno",
+            "chargeflapdcstatus": "Klapka nabíjania"
         },
         "ecoCard": {
             "ecoDisplay": "Ukazovateľ ECO",

--- a/src/languages/vi.json
+++ b/src/languages/vi.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Mở khóa một phần",
             "stateUnknown": "Không rõ",
             "stateUnlocked": "Đã mở khóa",
+            "statePressed": "Đã nhấn",
             "titleRemoteControl": "Điều khiển từ xa",
             "titleServices": "Dịch vụ",
             "toastCommandSent": "Lệnh đã được gửi thành công!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Cửa sau trái",
             "doorstatusrearright": "Cửa sau phải",
             "enginehoodstatus": "Nắp động cơ",
-            "sunroofstatus": "Cửa sổ trời"
+            "sunroofstatus": "Cửa sổ trời",
+            "chargeflapdcstatus": "Nắp cổng sạc"
         },
         "ecoCard": {
             "ecoDisplay": "Hiển thị Eco",

--- a/src/localize/string.json
+++ b/src/localize/string.json
@@ -15,6 +15,7 @@
             "statePartlyUnlocked": "Partly unlocked",
             "stateUnknown": "Unknown",
             "stateUnlocked": "Unlocked",
+            "statePressed": "Pressed",
             "titleRemoteControl": "Remote control",
             "titleServices": "Services",
             "toastCommandSent": "Command sent sucess!",
@@ -39,7 +40,8 @@
             "doorstatusrearleft": "Door rear left",
             "doorstatusrearright": "Door rear right",
             "enginehoodstatus": "Engine hood",
-            "sunroofstatus": "Sunroof"
+            "sunroofstatus": "Sunroof",
+            "chargeflapdcstatus": "Charging socket flap"
         },
         "ecoCard": {
             "ecoDisplay": "Eco display",

--- a/src/utils/ha-helpers.ts
+++ b/src/utils/ha-helpers.ts
@@ -47,7 +47,7 @@ export async function getVehicleEntities(hass: HomeAssistant, config: { entity?:
       if (prefix) {
         return e.entity_id.startsWith(prefix) && e.entity_id.endsWith(suffix);
       }
-      return e.unique_id.endsWith(suffix);
+      return e.unique_id.endsWith(suffix) || e.entity_id.endsWith(suffix);
     });
 
     if (entity) {
@@ -253,7 +253,7 @@ export async function handleFirstUpdated(
   }
 
   if (!component._config.selected_language) {
-    updates.selected_language = localStorage.getItem('selectedLanguage') || 'en';
+    updates.selected_language = component.hass.language;
     console.log('Selected language:', updates.selected_language);
   }
 

--- a/src/vehicle-info-card.ts
+++ b/src/vehicle-info-card.ts
@@ -885,7 +885,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
                   .icon="${icon}"
                   @click=${() => toggleMoreInfo(key)}
                 ></ha-icon>
-                <span style="text-transform: none;">${name}</span>
+                <span class="data-label">${name}</span>
               </div>
               <div class="data-value-unit" @click=${subCard?.toggleVisibility || (() => {})}>
                 <span class=${!active ? 'warning' : ''} style="text-transform: capitalize;">${state}</span>
@@ -918,7 +918,15 @@ export class VehicleCard extends LitElement implements LovelaceCard {
 
     // Iterate over the keys of the stateMapping object
     Object.keys(stateMapping).forEach((attribute) => {
-      const attributeState = this.getEntityAttribute(entityID, attribute);
+      let attributeState;
+      // Check if the attribute is the charge flap DC status
+      if (attribute === 'chargeflapdcstatus') {
+        attributeState = this.getEntityState(this.vehicleEntities?.chargeFlapDCStatus.entity_id);
+      } else {
+        attributeState = this.getEntityAttribute(entityID, attribute);
+      }
+      // Check if the attribute state
+
       if (attributeState !== undefined && attributeState !== null) {
         state[attribute] = attributeState;
       }
@@ -931,7 +939,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
           // Check if the state is valid and the attribute mapping exists
           if (rawState !== undefined && rawState !== null && stateMapping[attribute]) {
             const readableState = stateMapping[attribute].state[rawState] || 'Unknown';
-            const classState = rawState === '2' || rawState === false ? '' : 'warning';
+            const classState = rawState === '2' || rawState === false || rawState === '1' ? '' : 'warning';
             return html`
               <div class="data-row">
                 <span>${stateMapping[attribute].name}</span>
@@ -1026,7 +1034,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
                 <div class="data-row">
                   <div>
                     <ha-icon class="data-icon" .icon="${icon}"></ha-icon>
-                    <span>${name}</span>
+                    <span class="data-label">${name}</span>
                   </div>
                   <div
                     class="data-value-unit"


### PR DESCRIPTION
This pull request adds the "chargeflapdcstatus" attribute to the doorAttributes object in the code. This attribute represents the status of the charging socket flap and includes the following states: "card.common.stateOpen", "card.common.stateClosed", "card.common.statePressed", and "card.common.stateUnknown". This addition allows for the display and control of the charging socket flap status in the user interface.
