### PR TITLE
Swap up/down icons for windows

### DIFF
--- a/src/const/remote-control-keys.ts
+++ b/src/const/remote-control-keys.ts
@@ -49,8 +49,8 @@ export const serviceData = (lang: string) => ({
 
   windowsConfig: {
     service: {
-      OPEN: createService('windows_open', 'mdi:arrow-up-bold', 'serviceData.labelOpen', lang),
-      CLOSE: createService('windows_close', 'mdi:arrow-down-bold', 'serviceData.labelClose', lang),
+      OPEN: createService('windows_open', 'mdi:arrow-down-bold', 'serviceData.labelOpen', lang),
+      CLOSE: createService('windows_close', 'mdi:arrow-up-bold', 'serviceData.labelClose', lang),
       DATA_MOVE: createService('windows_move', 'mdi:swap-vertical-bold', 'serviceData.labelMove', lang),
     },
     data: {


### PR DESCRIPTION
Hi. Just a minor thing but under the window control you have an **up** arrow for opening and a **down** arrow for closing. I think these should be the other way round to show the direction the windows actually move.
