### PR TITLE
Add zone name display option on mini map

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -699,6 +699,12 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
         configValue: 'us_format',
         configType: 'map_popup_config',
       },
+      {
+        label: 'Use zone name',
+        value: mapPopupConfig?.use_zone_name ?? false,
+        configValue: 'use_zone_name',
+        configType: 'map_popup_config',
+      },
     ];
 
     const themeMode = [

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -37,14 +37,15 @@ export type Services = {
 type HISTORY_PERIOD = 'today' | 'yesterday' | undefined;
 
 export interface MapPopupConfig {
-  hours_to_show: number;
+  auto_fit?: boolean;
   default_zoom: number;
+  history_period?: HISTORY_PERIOD;
+  hours_to_show: number;
+  map_zoom?: number;
+  path_color?: string | undefined;
   theme_mode: THEME_MODE;
   us_format?: boolean;
-  path_color?: string | undefined;
-  auto_fit?: boolean;
-  map_zoom?: number;
-  history_period?: HISTORY_PERIOD;
+  use_zone_name?: boolean;
 }
 
 export type ImageConfig = {


### PR DESCRIPTION
Introduce a configuration option to display the zone name on the mini map when a device is within the designated zone.