### PR TITLE
Fix: Card width conflict with custom layout #162

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -23,6 +23,7 @@ ha-card {
   display: block;
   width: 100%;
   height: 100%;
+  max-width: 500px !important;
   padding: var(--vic-card-padding);
   background-color: var(--card-background-color);
 }
@@ -96,7 +97,7 @@ header h1 {
 
 #mini_map {
   position: relative;
-  min-width: var(--vic-card-full-width) !important;
+  min-width: calc(100% + (var(--vic-card-padding) * 2)) !important;
   width: 100%;
   height: 100%;
   margin: 0;


### PR DESCRIPTION
Adjustments made to the vehicle card's CSS and TypeScript to resolve the issue of the card expanding indefinitely in custom layouts. The maximum width of the card is now constrained, and the minimum width of the mini map has been recalibrated to ensure proper rendering within the defined layout. This prevents the card from pushing other columns out of view. Fixes #162