### PR TITLE
feat: optional leasing section driven by an external sensor

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -847,6 +847,14 @@ dialog::backdrop {
   background-color: var(--error-color);
 }
 
+.leasing-grid [good] {
+  color: var(--success-color);
+}
+
+.leasing-grid .item-icon .icon-background[good]::before {
+  background-color: var(--success-color);
+}
+
 .leasing-grid .item-content {
   display: flex;
   flex-direction: column;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -793,3 +793,83 @@ dialog::backdrop {
     opacity: 1;
   }
 }
+/* LEASING SECTION (chip grid like vehicle buttons) */
+.leasing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(calc((100% - 24px) / 2), 1fr));
+  grid-template-rows: auto;
+  grid-gap: var(--vic-gutter-gap);
+  margin-top: var(--vic-gutter-gap);
+}
+
+.leasing-grid .grid-item {
+  display: flex;
+  position: relative;
+  padding: var(--vic-gutter-gap) var(--vic-card-padding);
+  background: var(--secondary-background-color, var(--card-background-color, #fff));
+  box-shadow: var(--ha-card-box-shadow);
+  box-sizing: border-box;
+  border-radius: var(--ha-card-border-radius, 12px);
+  border-width: var(--ha-card-border-width, 1px);
+  border-style: solid;
+  border-color: var(--ha-card-border-color, var(--divider-color, #e0e0e0));
+  align-items: center;
+  height: 100%;
+  overflow: hidden;
+  cursor: pointer;
+  gap: 1em;
+}
+
+.leasing-grid .item-icon .icon-background {
+  position: relative;
+  width: var(--vic-icon-size);
+  height: var(--vic-icon-size);
+  border-radius: var(--vic-icon-border-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--secondary-text-color);
+}
+
+.leasing-grid .item-icon .icon-background::before {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: var(--disabled-text-color);
+  opacity: var(--vic-icon-bg-opacity);
+}
+
+.leasing-grid .item-icon .icon-background[error]::before {
+  background-color: var(--error-color);
+}
+
+.leasing-grid .item-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.leasing-grid .item-content .primary {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.leasing-grid .item-content .secondary {
+  color: var(--secondary-text-color);
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  text-overflow: ellipsis;
+}

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -144,6 +144,10 @@
             "payment": "Nachzahlung",
             "refund": "Erstattung",
             "costRefund": "Kosten / Erstattung",
+            "totalDistance": "Gesamtkilometer",
+            "startDate": "Startdatum",
+            "endDate": "Enddatum",
+            "monthlyAverage": "Aktuelle km/Monat",
             "days": "T",
             "months": "Mon."
         },

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -136,16 +136,15 @@
             "stateOpen": "Offen"
         },
         "leasingCard": {
-            "leaseRemaining": "Restlaufzeit",
-            "kmBalance": "km-Bilanz",
-            "projectedAtEnd": "Prognose Leasingende",
-            "projected": "Prognose",
+            "leaseRemaining": "Leasing-Restlaufzeit",
+            "kmBalance": "km-Saldo",
+            "projectedAtEnd": "Prognose Vertragsende",
             "excessKm": "Mehrkilometer",
             "underKm": "Minderkilometer",
             "payment": "Nachzahlung",
             "refund": "Erstattung",
             "costRefund": "Kosten / Erstattung",
-            "days": "Tage",
+            "days": "T",
             "months": "Mon."
         },
         "tripCard": {

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -139,6 +139,11 @@
             "leaseRemaining": "Restlaufzeit",
             "kmBalance": "km-Bilanz",
             "projectedAtEnd": "Prognose Leasingende",
+            "projected": "Prognose",
+            "excessKm": "Mehrkilometer",
+            "underKm": "Minderkilometer",
+            "payment": "Nachzahlung",
+            "refund": "Erstattung",
             "costRefund": "Kosten / Erstattung",
             "days": "Tage",
             "months": "Mon."

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -137,7 +137,7 @@
         },
         "leasingCard": {
             "leaseRemaining": "Leasing-Restlaufzeit",
-            "kmBalance": "km-Saldo",
+            "monthlyRemaining": "Restsaldo/Monat",
             "projectedAtEnd": "Prognose Vertragsende",
             "excessKm": "Mehrkilometer",
             "underKm": "Minderkilometer",

--- a/src/languages/de.json
+++ b/src/languages/de.json
@@ -135,6 +135,14 @@
             "stateClosed": "Geschlossen",
             "stateOpen": "Offen"
         },
+        "leasingCard": {
+            "leaseRemaining": "Restlaufzeit",
+            "kmBalance": "km-Bilanz",
+            "projectedAtEnd": "Prognose Leasingende",
+            "costRefund": "Kosten / Erstattung",
+            "days": "Tage",
+            "months": "Mon."
+        },
         "tripCard": {
             "adBlueLevel": "AdBlue-Stand",
             "averageSpeedReset": "Durchschnittsgeschwindigkeit",
@@ -217,6 +225,7 @@
         "buttonConfig": {
             "desc": "Konfigurieren Sie die Unterkarten für einzelne Schaltflächen.",
             "title": "Schaltflächenkonfiguration",
+            "leasingSensor": "Leasing-Sensor (optional)",
             "defaultCards": "Standardkarten",
             "customCards": "Benutzerdefinierte Karten",
             "addNewCard": "Neue Karte hinzufügen",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -135,6 +135,14 @@
             "stateClosed": "Closed",
             "stateOpen": "Open"
         },
+        "leasingCard": {
+            "leaseRemaining": "Lease remaining",
+            "kmBalance": "km balance",
+            "projectedAtEnd": "Projected at end",
+            "costRefund": "Cost / refund",
+            "days": "d",
+            "months": "mo"
+        },
         "tripCard": {
             "adBlueLevel": "AdBlue level",
             "averageSpeedReset": "Average speed",
@@ -217,6 +225,7 @@
         "buttonConfig": {
             "desc": "Configure the subcards for individual buttons.",
             "title": "Buttons configuration",
+            "leasingSensor": "Leasing sensor (optional)",
             "defaultCards": "Default cards",
             "customCards": "Custom cards",
             "addNewCard": "Add new card",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -137,7 +137,7 @@
         },
         "leasingCard": {
             "leaseRemaining": "Lease remaining",
-            "kmBalance": "km balance",
+            "monthlyRemaining": "Remaining / month",
             "projectedAtEnd": "Projected at end",
             "excessKm": "Excess mileage",
             "underKm": "Unused mileage",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -139,6 +139,11 @@
             "leaseRemaining": "Lease remaining",
             "kmBalance": "km balance",
             "projectedAtEnd": "Projected at end",
+            "projected": "Projected",
+            "excessKm": "Excess mileage",
+            "underKm": "Unused mileage",
+            "payment": "Additional payment",
+            "refund": "Refund",
             "costRefund": "Cost / refund",
             "days": "d",
             "months": "mo"

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -139,7 +139,6 @@
             "leaseRemaining": "Lease remaining",
             "kmBalance": "km balance",
             "projectedAtEnd": "Projected at end",
-            "projected": "Projected",
             "excessKm": "Excess mileage",
             "underKm": "Unused mileage",
             "payment": "Additional payment",

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -144,6 +144,10 @@
             "payment": "Additional payment",
             "refund": "Refund",
             "costRefund": "Cost / refund",
+            "totalDistance": "Total allowance",
+            "startDate": "Start date",
+            "endDate": "End date",
+            "monthlyAverage": "Current km/month",
             "days": "d",
             "months": "mo"
         },

--- a/src/legacy-card/components/editor/forms/base-card-schema.ts
+++ b/src/legacy-card/components/editor/forms/base-card-schema.ts
@@ -24,15 +24,18 @@ export const ENTITY_CARD_NAME_SCHEMA = memoizeOne(
     ] as const
 );
 
-export const LEASING_SCHEMA = [
-  {
-    name: 'leasing_entity',
-    label: 'Leasing sensor (optional)',
-    selector: {
-      entity: { domain: 'sensor' },
-    },
-  },
-] as const;
+export const LEASING_SCHEMA = memoizeOne(
+  (label: string) =>
+    [
+      {
+        name: 'leasing_entity',
+        label,
+        selector: {
+          entity: { domain: 'sensor' },
+        },
+      },
+    ] as const
+);
 
 export const SHOW_CONFIG_SCHEMA = memoizeOne((options: any[]) => [
   {

--- a/src/legacy-card/components/editor/forms/base-card-schema.ts
+++ b/src/legacy-card/components/editor/forms/base-card-schema.ts
@@ -21,15 +21,18 @@ export const ENTITY_CARD_NAME_SCHEMA = memoizeOne(
           },
         },
       },
-      {
-        name: 'leasing_entity',
-        label: 'Leasing sensor (optional)',
-        selector: {
-          entity: { domain: 'sensor' },
-        },
-      },
     ] as const
 );
+
+export const LEASING_SCHEMA = [
+  {
+    name: 'leasing_entity',
+    label: 'Leasing sensor (optional)',
+    selector: {
+      entity: { domain: 'sensor' },
+    },
+  },
+] as const;
 
 export const SHOW_CONFIG_SCHEMA = memoizeOne((options: any[]) => [
   {

--- a/src/legacy-card/components/editor/forms/base-card-schema.ts
+++ b/src/legacy-card/components/editor/forms/base-card-schema.ts
@@ -21,6 +21,13 @@ export const ENTITY_CARD_NAME_SCHEMA = memoizeOne(
           },
         },
       },
+      {
+        name: 'leasing_entity',
+        label: 'Leasing sensor (optional)',
+        selector: {
+          entity: { domain: 'sensor' },
+        },
+      },
     ] as const
 );
 

--- a/src/legacy-card/components/editor/forms/base-card-schema.ts
+++ b/src/legacy-card/components/editor/forms/base-card-schema.ts
@@ -24,18 +24,21 @@ export const ENTITY_CARD_NAME_SCHEMA = memoizeOne(
     ] as const
 );
 
-export const LEASING_SCHEMA = memoizeOne(
-  (label: string) =>
-    [
-      {
-        name: 'leasing_entity',
-        label,
-        selector: {
-          entity: { domain: 'sensor' },
-        },
-      },
-    ] as const
-);
+export const LEASING_SCHEMA = (label: string, itemToggles: { name: string; label: string }[]) => [
+  {
+    name: 'leasing_entity',
+    label,
+    selector: {
+      entity: { domain: 'sensor' },
+    },
+  },
+  {
+    name: '',
+    type: 'grid',
+    column_min_width: '140px',
+    schema: itemToggles.map((item) => ({ name: item.name, label: item.label, type: 'boolean' })),
+  },
+];
 
 export const SHOW_CONFIG_SCHEMA = memoizeOne((options: any[]) => [
   {

--- a/src/legacy-card/editor.ts
+++ b/src/legacy-card/editor.ts
@@ -36,6 +36,7 @@ import {
   CustomButtonTemplate,
   CustomCardUIEditor,
   ENTITY_CARD_NAME_SCHEMA,
+  LEASING_SCHEMA,
   LANG_SCHEMA,
   PanelImages,
   SERVICE_SCHEMA,
@@ -278,11 +279,7 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
 
   private _renderNameEntityForm(): TemplateResult {
     const modelName = this._modelName || '';
-    const DATA = {
-      entity: this._config.entity || '',
-      name: this._config.name || '',
-      leasing_entity: this._config.leasing_entity || '',
-    };
+    const DATA = { entity: this._config.entity || '', name: this._config.name || '' };
 
     return this._createHaForm(DATA, ENTITY_CARD_NAME_SCHEMA(modelName));
   }
@@ -310,7 +307,9 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
       hideHeader: true,
     });
 
-    return html`<ha-alert alert-type="info">${translate.info}</ha-alert>${defaultCardList}`;
+    const leasingForm = this._createHaForm({ leasing_entity: this._config.leasing_entity || '' }, LEASING_SCHEMA);
+
+    return html`<ha-alert alert-type="info">${translate.info}</ha-alert>${defaultCardList}${leasingForm}`;
   }
 
   private _renderCustomButtonPanel(): TemplateResult {

--- a/src/legacy-card/editor.ts
+++ b/src/legacy-card/editor.ts
@@ -307,9 +307,21 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
       hideHeader: true,
     });
 
+    const leasingToggles = [
+      { name: 'leasing_show_remaining', label: this.localize('card.leasingCard.leaseRemaining') },
+      { name: 'leasing_show_monthly', label: this.localize('card.leasingCard.monthlyRemaining') },
+      { name: 'leasing_show_projected', label: this.localize('card.leasingCard.projectedAtEnd') },
+      { name: 'leasing_show_cost', label: this.localize('card.leasingCard.costRefund') },
+    ];
     const leasingForm = this._createHaForm(
-      { leasing_entity: this._config.leasing_entity || '' },
-      LEASING_SCHEMA(localize('leasingSensor'))
+      {
+        leasing_entity: this._config.leasing_entity || '',
+        leasing_show_remaining: this._config.leasing_show_remaining !== false,
+        leasing_show_monthly: this._config.leasing_show_monthly !== false,
+        leasing_show_projected: this._config.leasing_show_projected !== false,
+        leasing_show_cost: this._config.leasing_show_cost !== false,
+      },
+      LEASING_SCHEMA(localize('leasingSensor'), leasingToggles)
     );
 
     return html`<ha-alert alert-type="info">${translate.info}</ha-alert>${defaultCardList}${leasingForm}`;

--- a/src/legacy-card/editor.ts
+++ b/src/legacy-card/editor.ts
@@ -307,7 +307,10 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
       hideHeader: true,
     });
 
-    const leasingForm = this._createHaForm({ leasing_entity: this._config.leasing_entity || '' }, LEASING_SCHEMA);
+    const leasingForm = this._createHaForm(
+      { leasing_entity: this._config.leasing_entity || '' },
+      LEASING_SCHEMA(localize('leasingSensor'))
+    );
 
     return html`<ha-alert alert-type="info">${translate.info}</ha-alert>${defaultCardList}${leasingForm}`;
   }

--- a/src/legacy-card/editor.ts
+++ b/src/legacy-card/editor.ts
@@ -278,7 +278,11 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
 
   private _renderNameEntityForm(): TemplateResult {
     const modelName = this._modelName || '';
-    const DATA = { entity: this._config.entity || '', name: this._config.name || '' };
+    const DATA = {
+      entity: this._config.entity || '',
+      name: this._config.name || '',
+      leasing_entity: this._config.leasing_entity || '',
+    };
 
     return this._createHaForm(DATA, ENTITY_CARD_NAME_SCHEMA(modelName));
   }

--- a/src/legacy-card/editor.ts
+++ b/src/legacy-card/editor.ts
@@ -312,6 +312,10 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
       { name: 'leasing_show_monthly', label: this.localize('card.leasingCard.monthlyRemaining') },
       { name: 'leasing_show_projected', label: this.localize('card.leasingCard.projectedAtEnd') },
       { name: 'leasing_show_cost', label: this.localize('card.leasingCard.costRefund') },
+      { name: 'leasing_show_total', label: this.localize('card.leasingCard.totalDistance') },
+      { name: 'leasing_show_start', label: this.localize('card.leasingCard.startDate') },
+      { name: 'leasing_show_end', label: this.localize('card.leasingCard.endDate') },
+      { name: 'leasing_show_average', label: this.localize('card.leasingCard.monthlyAverage') },
     ];
     const leasingForm = this._createHaForm(
       {
@@ -320,6 +324,10 @@ export class VehicleCardEditor extends LitElement implements LovelaceCardEditor 
         leasing_show_monthly: this._config.leasing_show_monthly !== false,
         leasing_show_projected: this._config.leasing_show_projected !== false,
         leasing_show_cost: this._config.leasing_show_cost !== false,
+        leasing_show_total: this._config.leasing_show_total !== false,
+        leasing_show_start: this._config.leasing_show_start !== false,
+        leasing_show_end: this._config.leasing_show_end !== false,
+        leasing_show_average: this._config.leasing_show_average !== false,
       },
       LEASING_SCHEMA(localize('leasingSensor'), leasingToggles)
     );

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -485,23 +485,22 @@ export class VehicleCard extends LitElement implements LovelaceCard {
       { icon: 'mdi:cash', name: 'Cost / refund', state: formatLeaseCost(projectedCost, currency), error: leaseDeltaError(projectedCost) },
     ];
     return html`
-      <div id="leasing" class="default-card">
-        <div class="data-header">Leasing</div>
-        <div class="data-box">
-          ${items.map(
-            ({ icon, name, state, error }) => html`
-              <div class="data-row">
-                <div>
-                  <ha-icon class="data-icon" .icon=${icon} @click=${() => this.toggleMoreInfo(leasingEntityId)}></ha-icon>
-                  <span class="data-label">${name}</span>
-                </div>
-                <div class="data-value-unit" ?error=${error} @click=${() => this.toggleMoreInfo(leasingEntityId)}>
-                  <span>${state}</span>
+      <div id="leasing" class="leasing-grid">
+        ${items.map(
+          ({ icon, name, state, error }) => html`
+            <div class="grid-item" @click=${() => this.toggleMoreInfo(leasingEntityId)}>
+              <div class="item-icon">
+                <div class="icon-background" ?error=${error}>
+                  <ha-icon .icon=${icon} ?error=${error}></ha-icon>
                 </div>
               </div>
-            `,
-          )}
-        </div>
+              <div class="item-content">
+                <div class="primary"><span>${name}</span></div>
+                <span class="secondary" ?error=${error}>${state}</span>
+              </div>
+            </div>
+          `,
+        )}
       </div>
     `;
   }
@@ -1739,7 +1738,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     if (show_buttons) gridRowSize += gridButtonsHeight;
     if (show_header_info) gridRowSize += headerInfoHeight;
     if (configName) gridRowSize += name;
-    if (this.config.leasing_entity) gridRowSize += 230 / ROWPX;
+    if (this.config.leasing_entity) gridRowSize += 130 / ROWPX;
     gridRowSize -= miniMapAtTopOrBottom;
 
     return gridRowSize;

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -52,6 +52,35 @@ import { EcoChart, RemoteControl, VehicleButtons, VehicleMap } from './component
 
 const ROWPX = 58;
 
+const leaseAttrNumber = (stateObj: any, key: string): number => {
+  const value = Number(stateObj?.attributes?.[key]);
+  return Number.isFinite(value) ? value : NaN;
+};
+
+const formatSignedDistance = (value: number, unit: string): string => {
+  if (!Number.isFinite(value)) return '—';
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? '+' : ''}${rounded.toLocaleString()} ${unit || 'km'}`;
+};
+
+// positive = extra distance / extra cost (error), negative = under distance / refund (good)
+const leaseDeltaError = (value: number): boolean => Number.isFinite(value) && Math.round(value) > 0;
+
+const formatLeaseRemaining = (days: number, months: number): string => {
+  if (Number.isFinite(days) && days < 61) return `${Math.max(0, Math.round(days))} d`;
+  if (Number.isFinite(months)) return `${months} mo`;
+  return '—';
+};
+
+const formatLeaseCost = (value: number, currency: string): string => {
+  if (!Number.isFinite(value)) return '—';
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(value);
+  } catch {
+    return `${value.toFixed(2)} ${currency || 'EUR'}`;
+  }
+};
+
 @customElement(VEHICLE_INFO_CARD_NAME)
 export class VehicleCard extends LitElement implements LovelaceCard {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -432,7 +461,48 @@ export class VehicleCard extends LitElement implements LovelaceCard {
               return '';
           }
         })}
+        ${this._renderLeasing()}
       </main>
+    `;
+  }
+
+  private _renderLeasing(): TemplateResult | typeof nothing {
+    const leasingEntityId = typeof this.config.leasing_entity === 'string' ? this.config.leasing_entity : '';
+    if (!leasingEntityId) return nothing;
+    const leaseState = this._hass.states[leasingEntityId];
+    const available = leaseState && !/(unknown|unavailable)/.test(leaseState.state);
+    const daysRemaining = available ? leaseAttrNumber(leaseState, 'days_remaining') : NaN;
+    const monthsRemaining = available ? leaseAttrNumber(leaseState, 'months_remaining') : NaN;
+    const deviation = available ? leaseAttrNumber(leaseState, 'deviation') : NaN;
+    const projectedDelta = available ? Number(leaseState.state) : NaN;
+    const projectedCost = available ? leaseAttrNumber(leaseState, 'projected_cost') : NaN;
+    const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
+    const currency = (this._hass.config as any)?.currency || 'EUR';
+    const items = [
+      { icon: 'mdi:calendar-clock', name: 'Lease remaining', state: formatLeaseRemaining(daysRemaining, monthsRemaining), error: false },
+      { icon: 'mdi:map-marker-distance', name: 'km balance', state: formatSignedDistance(deviation, distanceUnit), error: leaseDeltaError(deviation) },
+      { icon: 'mdi:chart-line', name: 'Projected at end', state: formatSignedDistance(projectedDelta, distanceUnit), error: leaseDeltaError(projectedDelta) },
+      { icon: 'mdi:cash', name: 'Cost / refund', state: formatLeaseCost(projectedCost, currency), error: leaseDeltaError(projectedCost) },
+    ];
+    return html`
+      <div id="leasing" class="default-card">
+        <div class="data-header">Leasing</div>
+        <div class="data-box">
+          ${items.map(
+            ({ icon, name, state, error }) => html`
+              <div class="data-row">
+                <div>
+                  <ha-icon class="data-icon" .icon=${icon} @click=${() => this.toggleMoreInfo(leasingEntityId)}></ha-icon>
+                  <span class="data-label">${name}</span>
+                </div>
+                <div class="data-value-unit" ?error=${error} @click=${() => this.toggleMoreInfo(leasingEntityId)}>
+                  <span>${state}</span>
+                </div>
+              </div>
+            `,
+          )}
+        </div>
+      </div>
     `;
   }
 
@@ -1669,6 +1739,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     if (show_buttons) gridRowSize += gridButtonsHeight;
     if (show_header_info) gridRowSize += headerInfoHeight;
     if (configName) gridRowSize += name;
+    if (this.config.leasing_entity) gridRowSize += 230 / ROWPX;
     gridRowSize -= miniMapAtTopOrBottom;
 
     return gridRowSize;

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -57,6 +57,12 @@ const leaseAttrNumber = (stateObj: any, key: string): number => {
   return Number.isFinite(value) ? value : NaN;
 };
 
+const formatSignedDistance = (value: number, unit: string): string => {
+  if (!Number.isFinite(value)) return '—';
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? '+' : ''}${rounded.toLocaleString()} ${unit || 'km'}`;
+};
+
 // absolute value — the direction (over/under) is carried by the case-dependent label
 const formatLeaseDistance = (value: number, unit: string): string => {
   if (!Number.isFinite(value)) return '—';
@@ -64,7 +70,8 @@ const formatLeaseDistance = (value: number, unit: string): string => {
 };
 
 // positive = extra distance / extra cost (error), negative = under distance / refund (good)
-const leaseDeltaError = (value: number): boolean => Number.isFinite(value) && Math.round(value) > 0;
+const leaseDir = (value: number): 'error' | 'good' | '' =>
+  !Number.isFinite(value) || Math.round(value) === 0 ? '' : value > 0 ? 'error' : 'good';
 
 const formatLeaseRemaining = (days: number, months: number, daysUnit: string, monthsUnit: string): string => {
   if (Number.isFinite(days) && days < 61) return `${Math.max(0, Math.round(days))} ${daysUnit}`;
@@ -74,11 +81,10 @@ const formatLeaseRemaining = (days: number, months: number, daysUnit: string, mo
 
 const formatLeaseCost = (value: number, currency: string): string => {
   if (!Number.isFinite(value)) return '—';
-  const absValue = Math.abs(value);
   try {
-    return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(absValue);
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(value);
   } catch {
-    return `${absValue.toFixed(2)} ${currency || 'EUR'}`;
+    return `${value.toFixed(2)} ${currency || 'EUR'}`;
   }
 };
 
@@ -480,57 +486,57 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
     const currency = (this._hass.config as any)?.currency || 'EUR';
     const localize = (key: string): string => this.localize(`card.leasingCard.${key}`);
-    const dirOf = (value: number): number =>
-      !Number.isFinite(value) || Math.round(value) === 0 ? 0 : value > 0 ? 1 : -1;
-    const kmName = (value: number, fallbackKey: string): string =>
-      dirOf(value) > 0 ? localize('excessKm') : dirOf(value) < 0 ? localize('underKm') : localize(fallbackKey);
+    const projectedDir = leaseDir(projectedDelta);
+    const costDir = leaseDir(projectedCost);
     const items = [
       {
         icon: 'mdi:calendar-clock',
         name: localize('leaseRemaining'),
         state: formatLeaseRemaining(daysRemaining, monthsRemaining, localize('days'), localize('months')),
-        error: false,
+        dir: '',
       },
       {
         icon: 'mdi:map-marker-distance',
-        name: kmName(deviation, 'kmBalance'),
-        state: formatLeaseDistance(deviation, distanceUnit),
-        error: leaseDeltaError(deviation),
+        name: localize('kmBalance'),
+        state: formatSignedDistance(deviation, distanceUnit),
+        dir: leaseDir(deviation),
       },
       {
+        // Directional label ("excess"/"under") carries the sign, so the value goes unsigned;
+        // neutral/unknown keeps the generic label with the signed value.
         icon: 'mdi:chart-line',
         name:
-          dirOf(projectedDelta) === 0
-            ? localize('projectedAtEnd')
-            : `${localize('projected')}: ${kmName(projectedDelta, 'projectedAtEnd')}`,
-        state: formatLeaseDistance(projectedDelta, distanceUnit),
-        error: leaseDeltaError(projectedDelta),
+          projectedDir === 'error'
+            ? localize('excessKm')
+            : projectedDir === 'good'
+              ? localize('underKm')
+              : localize('projectedAtEnd'),
+        state: projectedDir
+          ? formatLeaseDistance(projectedDelta, distanceUnit)
+          : formatSignedDistance(projectedDelta, distanceUnit),
+        dir: projectedDir,
       },
       {
         icon: 'mdi:cash',
         name:
-          dirOf(projectedCost) > 0
-            ? localize('payment')
-            : dirOf(projectedCost) < 0
-              ? localize('refund')
-              : localize('costRefund'),
-        state: formatLeaseCost(projectedCost, currency),
-        error: leaseDeltaError(projectedCost),
+          costDir === 'error' ? localize('payment') : costDir === 'good' ? localize('refund') : localize('costRefund'),
+        state: formatLeaseCost(costDir ? Math.abs(projectedCost) : projectedCost, currency),
+        dir: costDir,
       },
     ];
     return html`
       <div id="leasing" class="leasing-grid">
         ${items.map(
-          ({ icon, name, state, error }) => html`
+          ({ icon, name, state, dir }) => html`
             <div class="grid-item" @click=${() => this.toggleMoreInfo(leasingEntityId)}>
               <div class="item-icon">
-                <div class="icon-background" ?error=${error}>
-                  <ha-icon .icon=${icon} ?error=${error}></ha-icon>
+                <div class="icon-background" ?error=${dir === 'error'} ?good=${dir === 'good'}>
+                  <ha-icon .icon=${icon} ?error=${dir === 'error'} ?good=${dir === 'good'}></ha-icon>
                 </div>
               </div>
               <div class="item-content">
                 <div class="primary"><span>${name}</span></div>
-                <span class="secondary" ?error=${error}>${state}</span>
+                <span class="secondary" ?error=${dir === 'error'} ?good=${dir === 'good'}>${state}</span>
               </div>
             </div>
           `,

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -66,9 +66,9 @@ const formatSignedDistance = (value: number, unit: string): string => {
 // positive = extra distance / extra cost (error), negative = under distance / refund (good)
 const leaseDeltaError = (value: number): boolean => Number.isFinite(value) && Math.round(value) > 0;
 
-const formatLeaseRemaining = (days: number, months: number): string => {
-  if (Number.isFinite(days) && days < 61) return `${Math.max(0, Math.round(days))} d`;
-  if (Number.isFinite(months)) return `${months} mo`;
+const formatLeaseRemaining = (days: number, months: number, daysUnit: string, monthsUnit: string): string => {
+  if (Number.isFinite(days) && days < 61) return `${Math.max(0, Math.round(days))} ${daysUnit}`;
+  if (Number.isFinite(months)) return `${months.toLocaleString()} ${monthsUnit}`;
   return '—';
 };
 
@@ -478,11 +478,32 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const projectedCost = available ? leaseAttrNumber(leaseState, 'projected_cost') : NaN;
     const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
     const currency = (this._hass.config as any)?.currency || 'EUR';
+    const localize = (key: string): string => this.localize(`card.leasingCard.${key}`);
     const items = [
-      { icon: 'mdi:calendar-clock', name: 'Lease remaining', state: formatLeaseRemaining(daysRemaining, monthsRemaining), error: false },
-      { icon: 'mdi:map-marker-distance', name: 'km balance', state: formatSignedDistance(deviation, distanceUnit), error: leaseDeltaError(deviation) },
-      { icon: 'mdi:chart-line', name: 'Projected at end', state: formatSignedDistance(projectedDelta, distanceUnit), error: leaseDeltaError(projectedDelta) },
-      { icon: 'mdi:cash', name: 'Cost / refund', state: formatLeaseCost(projectedCost, currency), error: leaseDeltaError(projectedCost) },
+      {
+        icon: 'mdi:calendar-clock',
+        name: localize('leaseRemaining'),
+        state: formatLeaseRemaining(daysRemaining, monthsRemaining, localize('days'), localize('months')),
+        error: false,
+      },
+      {
+        icon: 'mdi:map-marker-distance',
+        name: localize('kmBalance'),
+        state: formatSignedDistance(deviation, distanceUnit),
+        error: leaseDeltaError(deviation),
+      },
+      {
+        icon: 'mdi:chart-line',
+        name: localize('projectedAtEnd'),
+        state: formatSignedDistance(projectedDelta, distanceUnit),
+        error: leaseDeltaError(projectedDelta),
+      },
+      {
+        icon: 'mdi:cash',
+        name: localize('costRefund'),
+        state: formatLeaseCost(projectedCost, currency),
+        error: leaseDeltaError(projectedCost),
+      },
     ];
     return html`
       <div id="leasing" class="leasing-grid">

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -79,6 +79,12 @@ const formatLeaseRemaining = (days: number, months: number, daysUnit: string, mo
   return '—';
 };
 
+const formatLeaseDate = (value: unknown, lang: string): string => {
+  if (!value) return '—';
+  const date = new Date(String(value));
+  return isNaN(date.getTime()) ? String(value) : date.toLocaleDateString(lang);
+};
+
 const formatLeaseCost = (value: number, currency: string): string => {
   if (!Number.isFinite(value)) return '—';
   try {
@@ -481,6 +487,10 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const daysRemaining = available ? leaseAttrNumber(leaseState, 'days_remaining') : NaN;
     const monthsRemaining = available ? leaseAttrNumber(leaseState, 'months_remaining') : NaN;
     const monthlyRemaining = available ? leaseAttrNumber(leaseState, 'monthly_remaining') : NaN;
+    const totalDistance = available ? leaseAttrNumber(leaseState, 'total_distance') : NaN;
+    const monthlyAverage = available ? leaseAttrNumber(leaseState, 'monthly_average') : NaN;
+    const leaseStart = available ? leaseState?.attributes?.lease_start : undefined;
+    const leaseEnd = available ? leaseState?.attributes?.lease_end : undefined;
     const projectedDelta = available ? Number(leaseState.state) : NaN;
     const projectedCost = available ? leaseAttrNumber(leaseState, 'projected_cost') : NaN;
     const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
@@ -530,6 +540,34 @@ export class VehicleCard extends LitElement implements LovelaceCard {
         state: formatLeaseCost(costDir ? Math.abs(projectedCost) : projectedCost, currency),
         dir: costDir,
         visible: show('leasing_show_cost'),
+      },
+      {
+        icon: 'mdi:counter',
+        name: localize('totalDistance'),
+        state: Number.isFinite(totalDistance) ? `${Math.round(totalDistance).toLocaleString()} ${distanceUnit}` : '—',
+        dir: '',
+        visible: show('leasing_show_total'),
+      },
+      {
+        icon: 'mdi:calendar-start',
+        name: localize('startDate'),
+        state: formatLeaseDate(leaseStart, this.userLang),
+        dir: '',
+        visible: show('leasing_show_start'),
+      },
+      {
+        icon: 'mdi:calendar-end',
+        name: localize('endDate'),
+        state: formatLeaseDate(leaseEnd, this.userLang),
+        dir: '',
+        visible: show('leasing_show_end'),
+      },
+      {
+        icon: 'mdi:speedometer',
+        name: localize('monthlyAverage'),
+        state: Number.isFinite(monthlyAverage) ? `${Math.round(monthlyAverage).toLocaleString()} ${distanceUnit}` : '—',
+        dir: '',
+        visible: show('leasing_show_average'),
       },
     ].filter((item) => item.visible);
     if (!items.length) return nothing;
@@ -1789,7 +1827,16 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     if (configName) gridRowSize += name;
     if (this.config.leasing_entity) {
       const visibleLeasingItems = (
-        ['leasing_show_remaining', 'leasing_show_monthly', 'leasing_show_projected', 'leasing_show_cost'] as const
+        [
+          'leasing_show_remaining',
+          'leasing_show_monthly',
+          'leasing_show_projected',
+          'leasing_show_cost',
+          'leasing_show_total',
+          'leasing_show_start',
+          'leasing_show_end',
+          'leasing_show_average',
+        ] as const
       ).filter((key) => this.config[key] !== false).length;
       gridRowSize += (Math.ceil(visibleLeasingItems / 2) * 65) / ROWPX;
     }

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -57,10 +57,10 @@ const leaseAttrNumber = (stateObj: any, key: string): number => {
   return Number.isFinite(value) ? value : NaN;
 };
 
-const formatSignedDistance = (value: number, unit: string): string => {
+// absolute value — the direction (over/under) is carried by the case-dependent label
+const formatLeaseDistance = (value: number, unit: string): string => {
   if (!Number.isFinite(value)) return '—';
-  const rounded = Math.round(value);
-  return `${rounded > 0 ? '+' : ''}${rounded.toLocaleString()} ${unit || 'km'}`;
+  return `${Math.abs(Math.round(value)).toLocaleString()} ${unit || 'km'}`;
 };
 
 // positive = extra distance / extra cost (error), negative = under distance / refund (good)
@@ -74,10 +74,11 @@ const formatLeaseRemaining = (days: number, months: number, daysUnit: string, mo
 
 const formatLeaseCost = (value: number, currency: string): string => {
   if (!Number.isFinite(value)) return '—';
+  const absValue = Math.abs(value);
   try {
-    return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(value);
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(absValue);
   } catch {
-    return `${value.toFixed(2)} ${currency || 'EUR'}`;
+    return `${absValue.toFixed(2)} ${currency || 'EUR'}`;
   }
 };
 
@@ -479,6 +480,10 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
     const currency = (this._hass.config as any)?.currency || 'EUR';
     const localize = (key: string): string => this.localize(`card.leasingCard.${key}`);
+    const dirOf = (value: number): number =>
+      !Number.isFinite(value) || Math.round(value) === 0 ? 0 : value > 0 ? 1 : -1;
+    const kmName = (value: number, fallbackKey: string): string =>
+      dirOf(value) > 0 ? localize('excessKm') : dirOf(value) < 0 ? localize('underKm') : localize(fallbackKey);
     const items = [
       {
         icon: 'mdi:calendar-clock',
@@ -488,19 +493,27 @@ export class VehicleCard extends LitElement implements LovelaceCard {
       },
       {
         icon: 'mdi:map-marker-distance',
-        name: localize('kmBalance'),
-        state: formatSignedDistance(deviation, distanceUnit),
+        name: kmName(deviation, 'kmBalance'),
+        state: formatLeaseDistance(deviation, distanceUnit),
         error: leaseDeltaError(deviation),
       },
       {
         icon: 'mdi:chart-line',
-        name: localize('projectedAtEnd'),
-        state: formatSignedDistance(projectedDelta, distanceUnit),
+        name:
+          dirOf(projectedDelta) === 0
+            ? localize('projectedAtEnd')
+            : `${localize('projected')}: ${kmName(projectedDelta, 'projectedAtEnd')}`,
+        state: formatLeaseDistance(projectedDelta, distanceUnit),
         error: leaseDeltaError(projectedDelta),
       },
       {
         icon: 'mdi:cash',
-        name: localize('costRefund'),
+        name:
+          dirOf(projectedCost) > 0
+            ? localize('payment')
+            : dirOf(projectedCost) < 0
+              ? localize('refund')
+              : localize('costRefund'),
         state: formatLeaseCost(projectedCost, currency),
         error: leaseDeltaError(projectedCost),
       },

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -480,7 +480,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const available = leaseState && !/(unknown|unavailable)/.test(leaseState.state);
     const daysRemaining = available ? leaseAttrNumber(leaseState, 'days_remaining') : NaN;
     const monthsRemaining = available ? leaseAttrNumber(leaseState, 'months_remaining') : NaN;
-    const deviation = available ? leaseAttrNumber(leaseState, 'deviation') : NaN;
+    const monthlyRemaining = available ? leaseAttrNumber(leaseState, 'monthly_remaining') : NaN;
     const projectedDelta = available ? Number(leaseState.state) : NaN;
     const projectedCost = available ? leaseAttrNumber(leaseState, 'projected_cost') : NaN;
     const distanceUnit = leaseState?.attributes?.unit_of_measurement || 'km';
@@ -496,10 +496,13 @@ export class VehicleCard extends LitElement implements LovelaceCard {
         dir: '',
       },
       {
+        // remaining allowed average distance per month; negative = allowance already used up
         icon: 'mdi:map-marker-distance',
-        name: localize('kmBalance'),
-        state: formatSignedDistance(deviation, distanceUnit),
-        dir: leaseDir(deviation),
+        name: localize('monthlyRemaining'),
+        state: Number.isFinite(monthlyRemaining)
+          ? `${Math.round(monthlyRemaining).toLocaleString()} ${distanceUnit}`
+          : '—',
+        dir: Number.isFinite(monthlyRemaining) && monthlyRemaining < 0 ? 'error' : '',
       },
       {
         // Directional label ("excess"/"under") carries the sign, so the value goes unsigned;

--- a/src/legacy-card/vehicle-info-card-legacy.ts
+++ b/src/legacy-card/vehicle-info-card-legacy.ts
@@ -488,12 +488,14 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     const localize = (key: string): string => this.localize(`card.leasingCard.${key}`);
     const projectedDir = leaseDir(projectedDelta);
     const costDir = leaseDir(projectedCost);
+    const show = (key: keyof VehicleCardConfig): boolean => this.config[key] !== false;
     const items = [
       {
         icon: 'mdi:calendar-clock',
         name: localize('leaseRemaining'),
         state: formatLeaseRemaining(daysRemaining, monthsRemaining, localize('days'), localize('months')),
         dir: '',
+        visible: show('leasing_show_remaining'),
       },
       {
         // remaining allowed average distance per month; negative = allowance already used up
@@ -503,6 +505,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
           ? `${Math.round(monthlyRemaining).toLocaleString()} ${distanceUnit}`
           : '—',
         dir: Number.isFinite(monthlyRemaining) && monthlyRemaining < 0 ? 'error' : '',
+        visible: show('leasing_show_monthly'),
       },
       {
         // Directional label ("excess"/"under") carries the sign, so the value goes unsigned;
@@ -518,6 +521,7 @@ export class VehicleCard extends LitElement implements LovelaceCard {
           ? formatLeaseDistance(projectedDelta, distanceUnit)
           : formatSignedDistance(projectedDelta, distanceUnit),
         dir: projectedDir,
+        visible: show('leasing_show_projected'),
       },
       {
         icon: 'mdi:cash',
@@ -525,8 +529,10 @@ export class VehicleCard extends LitElement implements LovelaceCard {
           costDir === 'error' ? localize('payment') : costDir === 'good' ? localize('refund') : localize('costRefund'),
         state: formatLeaseCost(costDir ? Math.abs(projectedCost) : projectedCost, currency),
         dir: costDir,
+        visible: show('leasing_show_cost'),
       },
-    ];
+    ].filter((item) => item.visible);
+    if (!items.length) return nothing;
     return html`
       <div id="leasing" class="leasing-grid">
         ${items.map(
@@ -1781,7 +1787,12 @@ export class VehicleCard extends LitElement implements LovelaceCard {
     if (show_buttons) gridRowSize += gridButtonsHeight;
     if (show_header_info) gridRowSize += headerInfoHeight;
     if (configName) gridRowSize += name;
-    if (this.config.leasing_entity) gridRowSize += 130 / ROWPX;
+    if (this.config.leasing_entity) {
+      const visibleLeasingItems = (
+        ['leasing_show_remaining', 'leasing_show_monthly', 'leasing_show_projected', 'leasing_show_cost'] as const
+      ).filter((key) => this.config[key] !== false).length;
+      gridRowSize += (Math.ceil(visibleLeasingItems / 2) * 65) / ROWPX;
+    }
     gridRowSize -= miniMapAtTopOrBottom;
 
     return gridRowSize;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -17,6 +17,7 @@ import { AddedCards, BaseButtonConfig } from './legacy-card-config/legacy-button
 export interface VehicleCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
+  leasing_entity?: string;
   selected_language?: string;
   model_name?: string;
   images?: ImageConfig[];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,6 +18,10 @@ export interface VehicleCardConfig extends LovelaceCardConfig {
   entity: string;
   name?: string;
   leasing_entity?: string;
+  leasing_show_remaining?: boolean;
+  leasing_show_monthly?: boolean;
+  leasing_show_projected?: boolean;
+  leasing_show_cost?: boolean;
   selected_language?: string;
   model_name?: string;
   images?: ImageConfig[];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -22,6 +22,10 @@ export interface VehicleCardConfig extends LovelaceCardConfig {
   leasing_show_monthly?: boolean;
   leasing_show_projected?: boolean;
   leasing_show_cost?: boolean;
+  leasing_show_total?: boolean;
+  leasing_show_start?: boolean;
+  leasing_show_end?: boolean;
+  leasing_show_average?: boolean;
   selected_language?: string;
   model_name?: string;
   images?: ImageConfig[];


### PR DESCRIPTION
## What

Adds an optional **Leasing** section to the (legacy) card: a grid of chips in the same style as the vehicle buttons, showing lease mileage tracking data from an external template sensor.

- New config key `leasing_entity` (entity picker in the editor, *Buttons configuration* panel). The section only renders when it is set — no change for existing configs.
- Up to 8 chips, each individually toggleable (`leasing_show_remaining/_monthly/_projected/_cost/_total/_start/_end/_average`, default on):
  - Lease remaining (days/months)
  - Remaining allowance per month
  - Projection at contract end — the label switches between *Excess mileage* / *Unused mileage* depending on the sign, value shown unsigned; excess renders in error color, unused in success color
  - Additional payment / Refund (same case-dependent labeling)
  - Total allowance, start date, end date (locale-formatted), current km/month
- Localized in English and German (`card.leasingCard.*`), English acts as fallback.

## Sensor contract

Works with any sensor whose state is the projected over/under distance at lease end and which exposes the attributes `days_remaining`, `months_remaining`, `monthly_remaining`, `monthly_average`, `total_distance`, `lease_start`, `lease_end`, `projected_cost` — e.g. the [Lease Mileage Tracker blueprint](https://github.com/elmars/ha-leasing-blueprint).

## Screenshots

Rendered with a German frontend: chips like *Leasing-Restlaufzeit 16,1 Mon.*, *Restsaldo/Monat 1.150 km*, *Mehrkilometer 21.258 km* (red), *Nachzahlung 7.993,97 €* (red).

🤖 Generated with [Claude Code](https://claude.com/claude-code) but still with head and heart of myself ;-)